### PR TITLE
Add pkg package

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Contributions are welcome! Read the [contribution guidelines](CONTRIBUTING.md) f
   
 ## Packages and Plugins
 ### Admin
+* [pkg](https://github.com/alexandregv/onset-pkg) - A package to manage your other packages (list/start/stop/restart/etc) with commands or keys.
 ### Mapping
 * [sandbox](https://github.com/dig/onset-sandbox-editor) - A sandbox editor which allows you to spawn objects or entities and save schematics and world.
 * [world](https://github.com/dig/onset-world) - Load your world created with [sandbox](https://github.com/dig/onset-sandbox-editor) (previous package).


### PR DESCRIPTION
[pkg](https://github.com/alexandregv/onset-pkg) is a package utility to manage your other packages (list/start/stop/restart/etc) with commands or keys.
This is useful when developping plugins, allowing you to restart it instantly with F5 instead of restarting the server.

Source code: https://github.com/alexandregv/onset-pkg
Dev: [alexandregv](https://github.com/alexandregv)