### PR TITLE
Add adminMenu package

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Contributions are welcome! Read the [contribution guidelines](CONTRIBUTING.md) f
 ## Packages and Plugins
 ### Admin
 * [pkg](https://github.com/alexandregv/onset-pkg) - A package to manage your other packages (list/start/stop/restart/etc) with commands or keys. Useful for devs.
+* [adminMenu](https://github.com/AnthonyTCS/onset-adminMenu/) - Admin menu with kick/ban/spawn/noclip/teleport.
 ### Mapping
 * [sandbox](https://github.com/dig/onset-sandbox-editor) - A sandbox editor which allows you to spawn objects or entities and save schematics and world.
 * [world](https://github.com/dig/onset-world) - Load your world created with [sandbox](https://github.com/dig/onset-sandbox-editor) (previous package).


### PR DESCRIPTION
[adminMenu](https://github.com/AnthonyTCS/onset-adminMenu/) is an admin menu which allows you to kick/ban/spawn/noclip/teleport.

Source code: https://github.com/AnthonyTCS/onset-adminMenu/
Dev: [AnthonyTCS](https://github.com/AnthonyTCS) (DiNO#&#x2060;7635)