### PR TITLE
Add onset-docker tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Contributions are welcome! Read the [contribution guidelines](CONTRIBUTING.md) f
 ## External Tools
 ### Websites
 ### Softwares
+* [onset-docker](https://hub.docker.com/r/alexandregv/onset-server) - Onset game server dockerized. Start a server with only one command.
 ### Other tools
 
 


### PR DESCRIPTION
[onset-docker](https://hub.docker.com/r/alexandregv/onset-server) is the [Onset](https://playonset.com) game server, dockerized. It allows you to start a server with only one command.

DockerHub: https://hub.docker.com/r/alexandregv/onset-server
GitHub: https://github.com/alexandregv/onset-pkg
Dev: [alexandregv](https://github.com/alexandregv)