### PR TITLE
Add HTTPPlugin plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ Contributions are welcome! Read the [contribution guidelines](CONTRIBUTING.md) f
 * [trafficlights](https://github.com/BlueMountainsIO/OnsetLuaScripts/tree/master/trafficlights) - A library to create trafficlights.
 * [kuz_Notifications](https://github.com/Kuzkay/OkayyNetwork/tree/master/kuz_Notifications) - Notifications library from [OkayyFramework](https://github.com/Kuzkay/OkayyNetwork).
 * [kuz_UI](https://github.com/Kuzkay/OkayyNetwork/tree/master/kuz_UI) - User Interface library from [OkayyFramework](https://github.com/Kuzkay/OkayyNetwork).
-* [HTTP Library](https://github.com/dig/onset-http-library) - A basic HTTP library (right now), uses [JavaPlugin](https://github.com/OnfireNetwork/OnsetJavaPlugin).
+* [HTTP Library](https://github.com/dig/onset-http-library) - A basic HTTP library, uses [JavaPlugin](https://github.com/OnfireNetwork/OnsetJavaPlugin) (not maintained).
+* [HTTP Plugin](https://github.com/dig/onset-http-plugin) - A powerful HTTP plugin (replaces [HTTP Library](https://github.com/dig/onset-http-library)).
 ### Other packages
 * [phone](https://github.com/rdlh/onset-phone) - A beautiful and powerful phone, made with VueJS.
 * [calculator](https://github.com/ShotenDev/Onset-calculator) - A simple calculator with a flat design.


### PR DESCRIPTION
[HTTP Plugin](https://github.com/dig/onset-http-plugin) is an HTTP plugin (library) which replaces [HTTP Library](https://github.com/dig/onset-http-library), without JVM this time :upside_down_face: 

Source code: https://github.com/dig/onset-http-plugin
Dev: [dig](https://github.com/dig)